### PR TITLE
Add AMD GPU support: a HIP build of the CUDA backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,14 @@ if(MPI_FOUND)
   add_subdirectory(fpie/core/mpi)
 endif()
 
-find_package(CUDA)
-if(CUDA_FOUND)
+option(USE_HIP "Build the GPU backend with HIP for AMD GPUs" OFF)
+if(USE_HIP)
+  # ROCm host: find_package(CUDA) would fail, so add the GPU backend directly;
+  # its CMakeLists builds the same sources through the HIP toolchain.
   add_subdirectory(fpie/core/cuda)
+else()
+  find_package(CUDA)
+  if(CUDA_FOUND)
+    add_subdirectory(fpie/core/cuda)
+  endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Supported Python versions: `3.10` to `3.13`.
 | GCC                                            | :heavy_check_mark: | :heavy_check_mark: | [docs](https://fpie.readthedocs.io/en/main/backend.html#gcc) | cmake, gcc                                                   |
 | OpenMP                                         | :heavy_check_mark: | :heavy_check_mark: | [docs](https://fpie.readthedocs.io/en/main/backend.html#openmp) | cmake, gcc (on macOS you need to change clang to gcc-11)     |
 | CUDA                                           | :heavy_check_mark: | :heavy_check_mark: | [docs](https://fpie.readthedocs.io/en/main/backend.html#cuda) | nvcc                                                         |
+| ROCm/HIP (CUDA backend on AMD GPUs)            | :heavy_check_mark: | :heavy_check_mark: | [docs](https://fpie.readthedocs.io/en/main/backend.html#amd-gpus-rocm-hip) | ROCm toolchain (`pip install .`, or cmake `-DUSE_HIP=ON`)   |
 | MPI                                            | :heavy_check_mark: | :heavy_check_mark: | [docs](https://fpie.readthedocs.io/en/main/backend.html#mpi) | `pip install mpi4py` and mpicc (on macOS: `brew install open-mpi`) |
 | [Taichi](https://github.com/taichi-dev/taichi) | :heavy_check_mark: | :heavy_check_mark: | [docs](https://fpie.readthedocs.io/en/main/backend.html#taichi) | `pip install taichi`                                         |
 
@@ -113,7 +114,7 @@ blend_video(
 
 ### Backend and Solver
 
-We have provided 7 backends. Each backend has two solvers: EquSolver and GridSolver. You can find the difference between these two solvers in the next section.
+We have provided 8 backends. Each backend has two solvers: EquSolver and GridSolver. You can find the difference between these two solvers in the next section.
 
 For different backend usage, please check out the related documentation [here](https://fpie.readthedocs.io/en/main/backend.html).
 

--- a/docs/backend.rst
+++ b/docs/backend.rst
@@ -336,6 +336,27 @@ For CUDA GridSolver, you also need to specify ``--grid-x`` and
    Time elapsed: 0.07s
    Successfully write image to result.jpg
 
+.. _amd-gpus-rocm-hip:
+
+AMD GPUs (ROCm/HIP)
+~~~~~~~~~~~~~~~~~~~~~
+
+The CUDA backend also runs on AMD GPUs through ROCm/HIP. The kernels are
+unchanged; a small compatibility header maps the CUDA runtime calls to HIP, and
+the build is selected with ``-DUSE_HIP=ON``. With a ROCm toolchain installed,
+configure the GPU backend directly with CMake:
+
+.. code:: bash
+
+   $ cmake <src> -DUSE_HIP=ON -DCMAKE_HIP_COMPILER=$(which hipcc) -DCMAKE_BUILD_TYPE=Release
+   $ make -j core_cuda
+
+By default CMake builds for the GPU installed in the build machine (detected
+automatically). To target a specific architecture, pass it explicitly, e.g.
+``-DCMAKE_HIP_ARCHITECTURES=gfx1100``. The backend is still selected at runtime
+with ``-b cuda`` (the name is kept for compatibility); on AMD it dispatches to
+the HIP build.
+
 .. _parallelization-strategy-cuda:
 
 Parallelization Strategy

--- a/docs/get_start.rst
+++ b/docs/get_start.rst
@@ -20,13 +20,14 @@ Linux/macOS
 Extensions
 ~~~~~~~~~~
 
-We provide 7 backends:
+We provide 8 backends:
 
 - NumPy, ``pip install numpy``;
 - `Numba <https://github.com/numba/numba>`__, ``pip install numba``;
 - GCC, needs cmake and gcc;
 - OpenMP, needs cmake and gcc (on macOS you need to change clang to gcc-11);
 - CUDA, needs nvcc;
+- ROCm/HIP (the CUDA backend on AMD GPUs), needs a ROCm toolchain (``pip install .``, or cmake ``-DUSE_HIP=ON``);
 - MPI, needs mpicc (on macOS: ``brew install open-mpi``) and ``pip install mpi4py``;
 - `Taichi <https://github.com/taichi-dev/taichi>`__, ``pip install taichi``.
 

--- a/fpie/core/cuda/CMakeLists.txt
+++ b/fpie/core/cuda/CMakeLists.txt
@@ -1,5 +1,4 @@
-find_package(CUDA REQUIRED)
-enable_language(CUDA)
+option(USE_HIP "Build the GPU backend with HIP for AMD GPUs" OFF)
 
 find_package(PythonInterp 3 REQUIRED)
 set(PYTHON_VERSION_FULL ${PYTHON_VERSION_STRING})
@@ -10,6 +9,30 @@ include_directories(${PYTHON_INCLUDE_DIRS})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3")
 
-pybind11_add_module(core_cuda solver.cc equ.cu grid.cu utils.cu)
-set_target_properties(core_cuda PROPERTIES CUDA_ARCHITECTURES OFF)
-target_link_libraries(core_cuda PRIVATE cudart)
+set(CUDA_SOURCES equ.cu grid.cu utils.cu)
+
+if(USE_HIP)
+  enable_language(HIP)
+  # enable_language(HIP) auto-detects the installed GPUs into
+  # CMAKE_HIP_ARCHITECTURES, so by default the backend builds for the GPU in this
+  # machine. Fall back to gfx90a only if nothing was detected (e.g. a build host
+  # with no AMD GPU); an explicit -DCMAKE_HIP_ARCHITECTURES overrides both.
+  if(NOT CMAKE_HIP_ARCHITECTURES)
+    set(CMAKE_HIP_ARCHITECTURES "gfx90a")
+  endif()
+  list(REMOVE_DUPLICATES CMAKE_HIP_ARCHITECTURES)
+  set_source_files_properties(${CUDA_SOURCES} PROPERTIES LANGUAGE HIP)
+  # NO_EXTRAS keeps pybind11 from injecting -flto: the HIP link step does not
+  # finalize LTO, so an LTO module is left without an exported PyInit_core_cuda
+  # (ImportError). LTO is a non-essential size optimization here.
+  pybind11_add_module(core_cuda NO_EXTRAS solver.cc ${CUDA_SOURCES})
+  set_target_properties(core_cuda PROPERTIES
+                        HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}")
+  target_compile_definitions(core_cuda PRIVATE USE_HIP)
+else()
+  find_package(CUDA REQUIRED)
+  enable_language(CUDA)
+  pybind11_add_module(core_cuda solver.cc ${CUDA_SOURCES})
+  set_target_properties(core_cuda PROPERTIES CUDA_ARCHITECTURES OFF)
+  target_link_libraries(core_cuda PRIVATE cudart)
+endif()

--- a/fpie/core/cuda/cuda_to_hip.h
+++ b/fpie/core/cuda/cuda_to_hip.h
@@ -1,0 +1,35 @@
+#ifndef FPIE_CORE_CUDA_CUDA_TO_HIP_H_
+#define FPIE_CORE_CUDA_CUDA_TO_HIP_H_
+
+// Single CUDA-to-HIP shim for the GPU backend. On ROCm it aliases the CUDA
+// runtime spellings this backend uses to their HIP equivalents; on NVIDIA it is
+// a plain include of the CUDA runtime. This is the only file that knows HIP, so
+// the kernels (equ.cu, grid.cu, utils.cu) stay in CUDA spelling and the NVIDIA
+// build is unchanged. Vector types (int4/float3, make_int4/make_float3) are
+// provided natively by HIP, so they need no alias.
+
+#if defined(USE_HIP) || defined(__HIP_PLATFORM_AMD__)
+
+#include <hip/hip_runtime.h>
+
+#define cudaDeviceProp           hipDeviceProp_t
+#define cudaDeviceSynchronize    hipDeviceSynchronize
+#define cudaError_t              hipError_t
+#define cudaFree                 hipFree
+#define cudaGetDeviceCount       hipGetDeviceCount
+#define cudaGetDeviceProperties  hipGetDeviceProperties
+#define cudaMalloc               hipMalloc
+#define cudaMemcpy               hipMemcpy
+#define cudaMemcpyDeviceToHost   hipMemcpyDeviceToHost
+#define cudaMemcpyHostToDevice   hipMemcpyHostToDevice
+#define cudaMemset               hipMemset
+
+#else  // CUDA
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <driver_functions.h>
+
+#endif
+
+#endif  // FPIE_CORE_CUDA_CUDA_TO_HIP_H_

--- a/fpie/core/cuda/utils.h
+++ b/fpie/core/cuda/utils.h
@@ -1,20 +1,23 @@
 #ifndef FPIE_CORE_CUDA_UTILS_H_
 #define FPIE_CORE_CUDA_UTILS_H_
 
-#include <cuda.h>
-#include <cuda_runtime.h>
-#include <driver_functions.h>
+#include "cuda_to_hip.h"
 
 // ops
 inline __host__ __device__ int4 operator*(int4 a, int b) {
   return make_int4(a.x * b, a.y * b, a.z * b, a.w * b);
 }
 
+#if !defined(USE_HIP)
+// HIP's vector types already define a componentwise operator+= for float3;
+// providing our own would make every `+=` ambiguous. CUDA's float3 is a plain
+// struct with no operators, so it still needs this. Same semantics either way.
 inline __host__ __device__ void operator+=(float3& a, float3 b) {
   a.x += b.x;
   a.y += b.y;
   a.z += b.z;
 }
+#endif
 
 inline __host__ __device__ float3 operator+(float3 a, float3 b) {
   return make_float3(a.x + b.x, a.y + b.y, a.z + b.z);

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,35 @@ def get_version() -> str:
     return init[init.index("__version__") + 2][1:-1]
 
 
+def _hip_cmake_args():
+    """Extra CMake args to build the GPU backend with HIP for AMD GPUs, or [].
+
+    Honors USE_HIP from the environment (USE_HIP=1/on/true forces it, 0/off/false
+    disables it). When USE_HIP is unset, auto-detects: if nvcc is absent but a
+    ROCm/HIP toolchain is present, build with HIP; otherwise take the default
+    NVIDIA/CUDA path. This lets ``pip install .`` build the GPU backend on an AMD
+    machine the same way it does on an NVIDIA one."""
+    env = os.environ.get("USE_HIP")
+    if env is not None:
+        if env.strip().lower() not in ("1", "on", "true", "yes"):
+            return []
+    else:
+        rocm_present = (
+            shutil.which("hipcc") or shutil.which("amdclang++")
+            or os.path.isdir(os.environ.get("ROCM_PATH", "/opt/rocm"))
+        )
+        if shutil.which("nvcc") is not None or not rocm_present:
+            return []
+    args = ["-DUSE_HIP=ON"]
+    rocm = os.environ.get("ROCM_PATH", "/opt/rocm")
+    rocm_clang = os.path.join(rocm, "llvm", "bin", "clang++")
+    if os.path.exists(rocm_clang):
+        args.append(f"-DCMAKE_HIP_COMPILER={rocm_clang}")
+    elif shutil.which("amdclang++"):
+        args.append(f"-DCMAKE_HIP_COMPILER={shutil.which('amdclang++')}")
+    return args
+
+
 # A CMakeExtension needs a sourcedir instead of a file list.
 # The name must be the _single_ output extension from the CMake build.
 # If you need multiple extensions, see scikit-build.
@@ -63,7 +92,7 @@ class CMakeBuild(build_ext):
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.path.sep}",
             f"-DPYTHON_EXECUTABLE={sys.executable}",
             "-DCMAKE_BUILD_TYPE=Release",
-        ]
+        ] + _hip_cmake_args()
         build_args = ["-j", f"{cpu_count()}"]
 
         if not os.path.exists(self.build_temp):


### PR DESCRIPTION
Adds a ROCm/HIP build of the GPU backend so fpie's solver runs on AMD GPUs. The project previously had no AMD support, and this needs no new dependency and leaves the NVIDIA/CUDA build unchanged.

## What it does

- The kernels keep their CUDA spelling: a new compat header (`fpie/core/cuda/cuda_to_hip.h`) aliases the handful of CUDA runtime symbols this backend uses to their HIP equivalents on AMD, and is a plain CUDA include on NVIDIA. So `equ.cu`/`grid.cu`/`utils.cu` are untouched and the NVIDIA path is byte-for-byte unchanged.
- A `USE_HIP` CMake option (default `OFF`) selects the GPU backend through the HIP toolchain. The GPU architecture is auto-detected by CMake from the build machine, with `gfx90a` as a fallback when nothing is detected; `-DCMAKE_HIP_ARCHITECTURES` overrides it.
- `setup.py` enables the HIP build automatically on the standard `pip install .` path when a ROCm toolchain is present and `nvcc` is not (or when `USE_HIP` is set in the environment), so AMD users install the GPU backend the same way NVIDIA users do.

## Two HIP-specific issues handled

- HIP's `float3` (a `HIP_vector_type`) already defines a componentwise `operator+=`, so the backend's own free `operator+=(float3&, float3)` is compiled only on the CUDA side, where `float3` is a plain struct that still needs it (identical semantics either way).
- pybind11's injected `-flto` leaves the HIP-linked module without an exported `PyInit_core_cuda` (ImportError), so the HIP target is built `NO_EXTRAS` to drop the LTO flags.

There are no kernel or algorithm changes. The backend table, get-started guide, and backend docs are updated to note AMD/ROCm support and how to build it.

## Test plan

Build the GPU backend through the HIP toolchain (or just `pip install .` on a ROCm machine, which now auto-enables it):

```bash
cmake <src> -DUSE_HIP=ON -DCMAKE_HIP_COMPILER=$(which hipcc) -DCMAKE_BUILD_TYPE=Release
make -j core_cuda
```

Validated on an AMD MI250X (gfx90a, ROCm 7.2.1) and an AMD Radeon Pro W7800 (gfx1100, ROCm 7.2.1) on the canonical Poisson blend (DIP2018 test1, 5000 Jacobi iterations). Both solvers (EquSolver and GridSolver) produce output bit-identical to the NumPy reference (max abs difference 0.0, residual [0,0,0]) and are deterministic run to run; the `-b cuda` CLI writes valid blends; the smoke suite passes (`pytest tests/test_smoke.py`: 7 passed, 1 pre-existing OpenMP skip). The built module links `libamdhip64` with no CUDA dependency.

This port was prepared with the assistance of Claude (AI), reviewed before submission.
